### PR TITLE
Bump jQuery version

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "backbone": "^1.2.3",
     "browserify": "^12.0.1",
-    "jquery": "^2.1.4",
+    "jquery": "^3.3.1",
     "retsly-js-sdk": "^0.8.3",
     "underscore": "^1.8.3"
   },


### PR DESCRIPTION
jQuery 2.1.4 has been deemed dangerous by a robot. Might as well upgrade even though I don't believe this code is in use anywhere. Candidate for deprecation and deletion.